### PR TITLE
nx_websocket_client_data_process: Return true opcode with fin bit

### DIFF
--- a/addons/websocket/nx_websocket_client.c
+++ b/addons/websocket/nx_websocket_client.c
@@ -2074,8 +2074,8 @@ UCHAR *data_ptr;
         case NX_WEBSOCKET_OPCODE_BINARY_FRAME:
         {
 
-            /* Assign the return opcode by the pre-stored opcode */
-            *code = client_ptr -> nx_websocket_client_frame_opcode;
+            /* Assign the return opcode */
+            *code = opcode | fin_bit;
 
             /* Update the offset by payload length */
             offset = payload_length;


### PR DESCRIPTION
Hello,

maybe this needs even better solution, but according to my knowledge of netxduo websocket client implementation, currently there is no way to properly discriminate:
- first text/binary frame packet, which can further be split into multiple tcp packets
- continuation packets, where each can be split into multiple tcp packets
- last continuation packet, again split into multiple tcp packets

This small patch is about giving the caller at least the same information as nx_websocket_client_data_process() function has.

But caller still needs to take nx_websocket_client_frame_data_received and nx_websocket_client_frame_data_length into account to detect the last tcp packet of last continuation frame.

If someone can proprose better solution, I'm willing to look into it.