### PR TITLE
Fix compile error with NX_DEBUG enabled

### DIFF
--- a/common/src/nx_ram_network_driver.c
+++ b/common/src/nx_ram_network_driver.c
@@ -274,7 +274,7 @@ ULONG        *ethernet_frame_ptr;
 
 #ifdef NX_DEBUG
         printf("NetX RAM Driver Initialization - %s\n", ip_ptr -> nx_ip_name);
-        printf("  IP Address =%08X\n", ip_ptr -> nx_ip_address);
+        printf("  IP Address =%08lX\n", ip_ptr -> nx_ip_address);
 #endif
 
         /* Once the Ethernet controller is initialized, the driver needs to


### PR DESCRIPTION
When compiling with NX_DEBUG enabled the
nx_ram_network_driver gives a compiler error when
printing the IP Address, since long sub-specifier
is missing.