### PR TITLE
Fix key_size_in_bits shift direction in _nx_crypto_method_hkdf_init

### DIFF
--- a/crypto_libraries/src/nx_crypto_hkdf.c
+++ b/crypto_libraries/src/nx_crypto_hkdf.c
@@ -103,7 +103,7 @@ NX_CRYPTO_KEEP UINT  _nx_crypto_method_hkdf_init(struct  NX_CRYPTO_METHOD_STRUCT
 
     /* Initialize IKM with key data. */
     hkdf->nx_crypto_hkdf_ikm = key;
-    hkdf->nx_crypto_hkdf_ikm_length = (key_size_in_bits << 3);
+    hkdf->nx_crypto_hkdf_ikm_length = (key_size_in_bits >> 3);
 
     /* Initialize HMAC and HASH methods. */
     hkdf->nx_crypto_hmac_method = NX_CRYPTO_NULL;

--- a/test/regression/nx_secure_test/nx_secure_hkdf_test.c
+++ b/test/regression/nx_secure_test/nx_secure_hkdf_test.c
@@ -42,6 +42,7 @@ static VOID thread_0_entry(ULONG thread_input)
 UINT i;
 NX_CRYPTO_METHOD *method_hkdf;
 NX_CRYPTO_METHOD *method_hash;
+NX_CRYPTO_HKDF *hkdf;
 
     /* Print out test information banner.  */
     printf("NetX Secure Test:   HKDF Test..........................................");
@@ -71,6 +72,10 @@ NX_CRYPTO_METHOD *method_hash;
         /* Initialize the IKM. */
         method_hkdf->nx_crypto_init(method_hkdf, (UCHAR*)(hkdf_test_data[i].ikm), hkdf_test_data[i].ikm_len << 3,
                                     NX_NULL, hkdf_metadata, sizeof(hkdf_metadata));
+
+        hkdf = (NX_CRYPTO_HKDF *)hkdf_metadata;
+        EXPECT_EQ((UCHAR *)hkdf_test_data[i].ikm, hkdf->nx_crypto_hkdf_ikm);
+        EXPECT_EQ(hkdf_test_data[i].ikm_len, hkdf->nx_crypto_hkdf_ikm_length);
 
         method_hkdf->nx_crypto_operation(NX_CRYPTO_HKDF_SET_HMAC, NX_NULL, &crypto_method_hmac,
                 					     NX_NULL, 0,NX_NULL, 0, NX_NULL, NX_NULL, 0, &hkdf_metadata,


### PR DESCRIPTION
This change fixes an error in the shift direction when setting the `nx_crypto_hkdf_ikm_length` in the `_nx_crypto_method_hkdf_init` function.

The parameter `key_size_in_bits` should be shifted to the right to set the correct length in bytes.

