### PR TITLE
Add listen queue callback function

### DIFF
--- a/common/inc/nx_api.h
+++ b/common/inc/nx_api.h
@@ -2226,6 +2226,12 @@ typedef struct NX_TCP_LISTEN_STRUCT
     NX_PACKET   *nx_tcp_listen_queue_head,
                 *nx_tcp_listen_queue_tail;
 
+#ifndef NX_DISABLE_EXTENDED_NOTIFY_SUPPORT
+    /* Define the callback function for notifying the host application of
+       a new connect request in the listen queue. */
+    VOID        (*nx_tcp_listen_queue_notify)(struct NX_TCP_LISTEN_STRUCT *listen_ptr);
+#endif
+
     /* Define the link between other TCP listen structures created by the application.  */
     struct NX_TCP_LISTEN_STRUCT
                 *nx_tcp_listen_next,

--- a/common/src/nx_tcp_packet_process.c
+++ b/common/src/nx_tcp_packet_process.c
@@ -108,6 +108,9 @@ NX_TCP_SOCKET               *socket_ptr;
 NX_TCP_HEADER               *tcp_header_ptr;
 struct NX_TCP_LISTEN_STRUCT *listen_ptr;
 VOID                         (*listen_callback)(NX_TCP_SOCKET *socket_ptr, UINT port);
+#ifndef NX_DISABLE_EXTENDED_NOTIFY_SUPPORT
+VOID                         (*queue_callback)(struct NX_TCP_LISTEN_STRUCT *listen_ptr);
+#endif
 ULONG                        option_words;
 ULONG                        mss = 0;
 ULONG                        checksum;
@@ -1011,6 +1014,17 @@ ULONG                        rwin_scale = 0xFF;
                         /* Release the packet.  */
                         _nx_packet_release(packet_ptr);
                     }
+
+#ifndef NX_DISABLE_EXTENDED_NOTIFY_SUPPORT
+                    /* If extended notify is enabled, call the listen_queue_notify function.
+                       This user-supplied function notifies the host application of
+                       a new connect request in the listen queue. */
+                    queue_callback = listen_ptr -> nx_tcp_listen_queue_notify;
+                    if (queue_callback)
+                    {
+                        (queue_callback)(listen_ptr);
+                    }
+#endif
                 }
 
                 /* Finished processing, just return.  */


### PR DESCRIPTION
Hi NetX support team,

In order to handle TCP connections on the same port, the host application must know when a connect request is added to the listen queue. Currently, the ```nx_tcp_listen_queue_current``` must be manually polled, since NetX doesn't provide any callbacks to inform about queued connections.

This pull request implements a callback function, which allows to notify the host application of a new connect request in the listen queue. ```NX_DISABLE_EXTENDED_NOTIFY_SUPPORT``` symbol has been used to control the callback, similar to ```nx_tcp_socket_syn_received_notify``` and other optional callbacks (disabled by default, the ```NX_ENABLE_EXTENDED_NOTIFY_SUPPORT``` must be defined in the config to enable it).

Please review. Hopefully the feature is useful enough to be merged into the main codebase.
