### PR TITLE
fix prepend ptr when sequence num. changes

### DIFF
--- a/common/src/nx_tcp_socket_send_internal.c
+++ b/common/src/nx_tcp_socket_send_internal.c
@@ -828,6 +828,11 @@ UINT            compute_checksum = 1;
                 {
                     _nx_packet_release(send_packet);
                 }
+                else
+                {
+                    send_packet -> nx_packet_prepend_ptr += sizeof(NX_TCP_HEADER);
+                    send_packet -> nx_packet_length -= sizeof(NX_TCP_HEADER);
+                }
 
                 /* Regain exclusive access to IP instance. */
                 tx_mutex_get(&(ip_ptr -> nx_ip_protection), TX_WAIT_FOREVER);


### PR DESCRIPTION
in case of multiple threads handling multiple packets it might happen that the sequence number of a paket changes before it got send out. In that case the checksum for that packet needs to be recalculated and the new sequence number must be added to the tcp header. 
When this is done, the size of the TCP Header will be removed from the available headspace and length twice for a packet which later on results in an assertion because the prepend_ptr will be smaller then the start_ptr.
This is fixed by adding the header size before hitting the continue statement of the for loop.