### PR TITLE
When using PSK for TLS authentication, look up and use the PSK ID requested by the client

### DIFF
--- a/nx_secure/src/nx_secure_generate_premaster_secret.c
+++ b/nx_secure/src/nx_secure_generate_premaster_secret.c
@@ -114,7 +114,7 @@ UINT					   pre_master_secret_size;
 #if defined(NX_SECURE_ENABLE_ECC_CIPHERSUITE) && !defined(NX_SECURE_DISABLE_X509)
     if (ciphersuite -> nx_secure_tls_public_cipher -> nx_crypto_algorithm == NX_CRYPTO_KEY_EXCHANGE_ECDHE)
     {
-    #ifdef NX_SECURE_ENABLE_PSK_CIPHERSUITES    
+    #ifdef NX_SECURE_ENABLE_PSK_CIPHERSUITES
     	if(ciphersuite->nx_secure_tls_public_auth->nx_crypto_algorithm == NX_CRYPTO_KEY_EXCHANGE_PSK)
     	{
     		/* From RFC 5489:
@@ -296,7 +296,7 @@ UINT					   pre_master_secret_size;
             }
             if (psk_length == 0)
             {
-                return(NX_OPTION_ERROR);
+                return(NX_SECURE_TLS_NO_MATCHING_PSK);
             }
         }
         else

--- a/nx_secure/src/nx_secure_generate_premaster_secret.c
+++ b/nx_secure/src/nx_secure_generate_premaster_secret.c
@@ -280,9 +280,24 @@ UINT					   pre_master_secret_size;
         /* Now, using the identity as a key, find the PSK in our PSK store. */
         if (session_type == NX_SECURE_TLS_SESSION_TYPE_SERVER)
         {
-            /* Server just uses its PSK. */
-            psk_data = tls_credentials -> nx_secure_tls_psk_store[0].nx_secure_tls_psk_data;
-            psk_length = tls_credentials -> nx_secure_tls_psk_store[0].nx_secure_tls_psk_data_size;
+            /* Attempt to find the PSK ID requested by the client in the ClientKeyExchange message. */
+            psk_length = 0;
+            const UINT client_psk_id_size = tls_credentials -> nx_secure_tls_remote_psk_id_size;
+            const UCHAR* client_psk_id = tls_credentials -> nx_secure_tls_remote_psk_id;
+            for (i = 0; i < NX_SECURE_TLS_MAX_PSK_KEYS; i++)
+            {
+                if ((client_psk_id_size == tls_credentials -> nx_secure_tls_psk_store[i].nx_secure_tls_psk_id_size) &&
+                    (NX_SECURE_MEMCMP(client_psk_id, tls_credentials -> nx_secure_tls_psk_store[i].nx_secure_tls_psk_id, client_psk_id_size) == 0))
+                {
+                    psk_data = tls_credentials -> nx_secure_tls_psk_store[i].nx_secure_tls_psk_data;
+                    psk_length = tls_credentials -> nx_secure_tls_psk_store[i].nx_secure_tls_psk_data_size;
+                    break;
+                }
+            }
+            if (psk_length == 0)
+            {
+                return(NX_OPTION_ERROR);
+            }
         }
         else
         {

--- a/nx_secure/src/nx_secure_process_client_key_exchange.c
+++ b/nx_secure/src/nx_secure_process_client_key_exchange.c
@@ -178,6 +178,14 @@ UINT                                private_key_length;
         /* Check for PSK ciphersuites and generate the pre-master-secret. */
         if (ciphersuite -> nx_secure_tls_public_auth -> nx_crypto_algorithm == NX_CRYPTO_KEY_EXCHANGE_PSK)
         {
+            /* Store the requested PSK ID in the TLS credentials. */
+            if (message_length < 2)
+            {
+                return NX_INVALID_PACKET;
+            }
+            tls_credentials -> nx_secure_tls_remote_psk_id_size = ((packet_buffer[0] << 8) | packet_buffer[1]);
+            NX_SECURE_MEMCPY(tls_credentials -> nx_secure_tls_remote_psk_id, &packet_buffer[2], tls_credentials -> nx_secure_tls_remote_psk_id_size);
+
             status = _nx_secure_generate_premaster_secret(ciphersuite, protocol_version, tls_key_material, tls_credentials,
                                                           NX_SECURE_TLS_SESSION_TYPE_SERVER, received_remote_credentials,
                                                           public_cipher_metadata, public_cipher_metadata_size, tls_ecc_curves);

--- a/nx_secure/src/nx_secure_process_client_key_exchange.c
+++ b/nx_secure/src/nx_secure_process_client_key_exchange.c
@@ -188,6 +188,10 @@ UINT                                private_key_length;
             {
                 return NX_SIZE_ERROR;
             }
+            if (message_length < 2 + tls_credentials -> nx_secure_tls_remote_psk_id_size)
+            {
+                return NX_SECURE_TLS_INCORRECT_MESSAGE_LENGTH;
+            }
             NX_SECURE_MEMCPY(tls_credentials -> nx_secure_tls_remote_psk_id, &packet_buffer[2], tls_credentials -> nx_secure_tls_remote_psk_id_size);
 
             status = _nx_secure_generate_premaster_secret(ciphersuite, protocol_version, tls_key_material, tls_credentials,

--- a/nx_secure/src/nx_secure_process_client_key_exchange.c
+++ b/nx_secure/src/nx_secure_process_client_key_exchange.c
@@ -184,6 +184,10 @@ UINT                                private_key_length;
                 return NX_INVALID_PACKET;
             }
             tls_credentials -> nx_secure_tls_remote_psk_id_size = ((packet_buffer[0] << 8) | packet_buffer[1]);
+            if (tls_credentials -> nx_secure_tls_remote_psk_id_size > NX_SECURE_TLS_MAX_PSK_ID_SIZE)
+            {
+                return NX_SIZE_ERROR;
+            }
             NX_SECURE_MEMCPY(tls_credentials -> nx_secure_tls_remote_psk_id, &packet_buffer[2], tls_credentials -> nx_secure_tls_remote_psk_id_size);
 
             status = _nx_secure_generate_premaster_secret(ciphersuite, protocol_version, tls_key_material, tls_credentials,


### PR DESCRIPTION
When acting as TLS server and using PSK based authentication, NetX currently just blindly selects the first available key from the PSK key store. It is up to the client to request a PSK ID to use to establish the connection in the ClientKeyExchange message. This patch stores the remote PSK ID requested by the client in the TLS credentials, then looks up the correct key in the PSK keystore to proceed with the authentication.

See chapter 2 of [RFC 4279 Pre-Shared Key Ciphersuites for Transport Layer Security (TLS)](https://datatracker.ietf.org/doc/html/rfc4279#section-2)

