### PR TITLE
Fixed TLS 1.3 record de-padding in _nx_secure_tls_process_record (RFC 8446 §5.4)

### DIFF
--- a/nx_secure/inc/nx_secure_tls.h
+++ b/nx_secure/inc/nx_secure_tls.h
@@ -1407,6 +1407,8 @@ typedef struct NX_SECURE_TLS_SESSION_STRUCT
 
 #if (NX_SECURE_TLS_TLS_1_3_ENABLED)
 UINT _nx_secure_tls_1_3_crypto_init(NX_SECURE_TLS_SESSION *tls_session);
+UINT _nx_secure_tls_1_3_strip_padding(NX_PACKET *decrypted_packet, USHORT *message_type_ptr,
+                                      UINT *message_length_ptr);
 UINT _nx_secure_tls_1_3_client_handshake(NX_SECURE_TLS_SESSION *tls_session, UCHAR *packet_buffer,
                                          UINT data_length, ULONG wait_option);
 UINT _nx_secure_tls_1_3_server_handshake(NX_SECURE_TLS_SESSION *tls_session, UCHAR *packet_buffer,

--- a/nx_secure/src/nx_secure_tls_process_record.c
+++ b/nx_secure/src/nx_secure_tls_process_record.c
@@ -301,7 +301,7 @@ NX_PACKET *decrypted_packet;
                     }
                     if (message_type == 0)
                     {
-                        error_status = NX_SECURE_TLS_INVALID_PACKET;
+                        error_status = NX_SECURE_TLS_UNEXPECTED_MESSAGE;
                         message_length = 0;
                     }
                     else

--- a/nx_secure/src/nx_secure_tls_process_record.c
+++ b/nx_secure/src/nx_secure_tls_process_record.c
@@ -86,7 +86,11 @@ UCHAR      header_data[NX_SECURE_TLS_RECORD_HEADER_SIZE] = {0}; /* DTLS record h
 USHORT     message_type;
 UINT       message_length;
 ULONG      bytes_copied;
-ULONG      scan_offset;
+NX_PACKET *scan_fragment;
+UCHAR     *scan_ptr;
+ULONG      running_offset;
+ULONG      last_nonzero_offset;
+UCHAR      last_nonzero_byte;
 UCHAR     *packet_data = NX_NULL;
 ULONG      record_offset = 0;
 ULONG      record_offset_next = 0;
@@ -279,34 +283,43 @@ NX_PACKET *decrypted_packet;
 
                     /* RFC 8446 §5.4: the inner content type is the last
                        non-zero byte of the plaintext; any bytes after it are
-                       record padding to be stripped. */
-                    scan_offset = decrypted_packet -> nx_packet_length;
-                    message_type = 0;
-                    while (scan_offset > 0)
+                       record padding to be stripped. Walk the packet chain
+                       directly and always visit every byte, so the cost does
+                       not depend on how much padding the peer added — the
+                       neighbouring TLS 1.2 path takes the same stance for
+                       exactly this reason (see the MAC-check comment below). */
+                    last_nonzero_offset = 0;
+                    last_nonzero_byte   = 0;
+                    running_offset      = 0;
+                    scan_fragment       = decrypted_packet;
+                    while (scan_fragment != NX_NULL)
                     {
-                        scan_offset--;
-                        status = nx_packet_data_extract_offset(decrypted_packet,
-                                                               scan_offset,
-                                                               &message_type, 1, &bytes_copied);
-                        if (status || (bytes_copied != 1))
+                        for (scan_ptr = scan_fragment -> nx_packet_prepend_ptr;
+                             scan_ptr < scan_fragment -> nx_packet_append_ptr;
+                             scan_ptr++)
                         {
-                            error_status = NX_SECURE_TLS_INVALID_PACKET;
-                            message_type = 0;
-                            break;
+                            if (*scan_ptr != 0)
+                            {
+                                last_nonzero_byte   = *scan_ptr;
+                                last_nonzero_offset = running_offset;
+                            }
+                            running_offset++;
                         }
-                        if (message_type != 0)
-                        {
-                            break;
-                        }
+                        scan_fragment = scan_fragment -> nx_packet_next;
                     }
-                    if (message_type == 0)
+                    if (last_nonzero_byte == 0)
                     {
-                        error_status = NX_SECURE_TLS_UNEXPECTED_MESSAGE;
+                        /* No non-zero byte in the plaintext: the peer sent a
+                           record with no inner content type. RFC 8446 §5.4
+                           requires an "unexpected_message" alert. */
+                        error_status   = NX_SECURE_TLS_UNEXPECTED_MESSAGE;
+                        message_type   = 0;
                         message_length = 0;
                     }
                     else
                     {
-                        message_length = scan_offset;
+                        message_type   = last_nonzero_byte;
+                        message_length = last_nonzero_offset;
                     }
                     decrypted_packet -> nx_packet_length = message_length;
 

--- a/nx_secure/src/nx_secure_tls_process_record.c
+++ b/nx_secure/src/nx_secure_tls_process_record.c
@@ -86,6 +86,7 @@ UCHAR      header_data[NX_SECURE_TLS_RECORD_HEADER_SIZE] = {0}; /* DTLS record h
 USHORT     message_type;
 UINT       message_length;
 ULONG      bytes_copied;
+ULONG      scan_offset;
 UCHAR     *packet_data = NX_NULL;
 ULONG      record_offset = 0;
 ULONG      record_offset_next = 0;
@@ -277,42 +278,37 @@ NX_PACKET *decrypted_packet;
                 {
 
                     /* RFC 8446 §5.4: the inner content type is the last
-                     * NON-ZERO byte of the plaintext; everything after it is
-                     * record padding. Reading the literal last byte broke any
-                     * padded record (Java JDK HttpClient pads by default) —
-                     * scan back, skip the zeros.
-                     */
+                       non-zero byte of the plaintext; any bytes after it are
+                       record padding to be stripped. */
+                    scan_offset = decrypted_packet -> nx_packet_length;
+                    message_type = 0;
+                    while (scan_offset > 0)
                     {
-                        ULONG scan_offset = decrypted_packet -> nx_packet_length;
-                        message_type = 0;
-                        while (scan_offset > 0)
-                        {
-                            scan_offset--;
-                            status = nx_packet_data_extract_offset(decrypted_packet,
-                                                                   scan_offset,
-                                                                   &message_type, 1, &bytes_copied);
-                            if (status || (bytes_copied != 1))
-                            {
-                                error_status = NX_SECURE_TLS_INVALID_PACKET;
-                                message_type = 0;
-                                break;
-                            }
-                            if (message_type != 0)
-                            {
-                                break;
-                            }
-                        }
-                        if (message_type == 0)
+                        scan_offset--;
+                        status = nx_packet_data_extract_offset(decrypted_packet,
+                                                               scan_offset,
+                                                               &message_type, 1, &bytes_copied);
+                        if (status || (bytes_copied != 1))
                         {
                             error_status = NX_SECURE_TLS_INVALID_PACKET;
-                            message_length = 0;
+                            message_type = 0;
+                            break;
                         }
-                        else
+                        if (message_type != 0)
                         {
-                            message_length = scan_offset;
+                            break;
                         }
-                        decrypted_packet -> nx_packet_length = message_length;
                     }
+                    if (message_type == 0)
+                    {
+                        error_status = NX_SECURE_TLS_INVALID_PACKET;
+                        message_length = 0;
+                    }
+                    else
+                    {
+                        message_length = scan_offset;
+                    }
+                    decrypted_packet -> nx_packet_length = message_length;
 
                     /* Increment the sequence number. This is done in the MAC verify
                     step for 1.2 and earlier, but AEAD includes the MAC so we don't

--- a/nx_secure/src/nx_secure_tls_process_record.c
+++ b/nx_secure/src/nx_secure_tls_process_record.c
@@ -26,6 +26,12 @@
 
 static VOID _nx_secure_tls_packet_trim(NX_PACKET *packet_ptr);
 
+#if (NX_SECURE_TLS_TLS_1_3_ENABLED)
+UINT _nx_secure_tls_1_3_strip_padding(NX_PACKET *decrypted_packet,
+                                      USHORT *message_type_ptr,
+                                      UINT *message_length_ptr);
+#endif
+
 /**************************************************************************/
 /*                                                                        */
 /*  FUNCTION                                               RELEASE        */
@@ -86,11 +92,6 @@ UCHAR      header_data[NX_SECURE_TLS_RECORD_HEADER_SIZE] = {0}; /* DTLS record h
 USHORT     message_type;
 UINT       message_length;
 ULONG      bytes_copied;
-NX_PACKET *scan_fragment;
-UCHAR     *scan_ptr;
-ULONG      running_offset;
-ULONG      last_nonzero_offset;
-UCHAR      last_nonzero_byte;
 UCHAR     *packet_data = NX_NULL;
 ULONG      record_offset = 0;
 ULONG      record_offset_next = 0;
@@ -281,47 +282,9 @@ NX_PACKET *decrypted_packet;
                 if (status == NX_SECURE_TLS_SUCCESS)
                 {
 
-                    /* RFC 8446 §5.4: the inner content type is the last
-                       non-zero byte of the plaintext; any bytes after it are
-                       record padding to be stripped. Walk the packet chain
-                       directly and always visit every byte, so the cost does
-                       not depend on how much padding the peer added — the
-                       neighbouring TLS 1.2 path takes the same stance for
-                       exactly this reason (see the MAC-check comment below). */
-                    last_nonzero_offset = 0;
-                    last_nonzero_byte   = 0;
-                    running_offset      = 0;
-                    scan_fragment       = decrypted_packet;
-                    while (scan_fragment != NX_NULL)
-                    {
-                        for (scan_ptr = scan_fragment -> nx_packet_prepend_ptr;
-                             scan_ptr < scan_fragment -> nx_packet_append_ptr;
-                             scan_ptr++)
-                        {
-                            if (*scan_ptr != 0)
-                            {
-                                last_nonzero_byte   = *scan_ptr;
-                                last_nonzero_offset = running_offset;
-                            }
-                            running_offset++;
-                        }
-                        scan_fragment = scan_fragment -> nx_packet_next;
-                    }
-                    if (last_nonzero_byte == 0)
-                    {
-                        /* No non-zero byte in the plaintext: the peer sent a
-                           record with no inner content type. RFC 8446 §5.4
-                           requires an "unexpected_message" alert. */
-                        error_status   = NX_SECURE_TLS_UNEXPECTED_MESSAGE;
-                        message_type   = 0;
-                        message_length = 0;
-                    }
-                    else
-                    {
-                        message_type   = last_nonzero_byte;
-                        message_length = last_nonzero_offset;
-                    }
-                    decrypted_packet -> nx_packet_length = message_length;
+                    error_status = _nx_secure_tls_1_3_strip_padding(decrypted_packet,
+                                                                    &message_type,
+                                                                    &message_length);
 
                     /* Increment the sequence number. This is done in the MAC verify
                     step for 1.2 and earlier, but AEAD includes the MAC so we don't
@@ -676,3 +639,78 @@ NX_PACKET *current_ptr;
         message_length -= (ULONG)(current_ptr -> nx_packet_append_ptr - current_ptr -> nx_packet_prepend_ptr);
     }
 }
+
+
+#if (NX_SECURE_TLS_TLS_1_3_ENABLED)
+/**************************************************************************/
+/*                                                                        */
+/*  FUNCTION                                               RELEASE        */
+/*                                                                        */
+/*    _nx_secure_tls_1_3_strip_padding                    PORTABLE C      */
+/*                                                                        */
+/*  AUTHOR                                                                */
+/*                                                                        */
+/*    Edouard MALOT                                                       */
+/*                                                                        */
+/*  DESCRIPTION                                                           */
+/*                                                                        */
+/*    Recover the inner content type from a decrypted TLS 1.3 record and  */
+/*    strip the trailing zero-byte padding. Per RFC 8446 §5.4, the inner  */
+/*    content type is the last non-zero byte of the plaintext; all bytes  */
+/*    after it are padding. The scan visits every plaintext byte, so its  */
+/*    cost is independent of how much padding the peer added.             */
+/*                                                                        */
+/*  INPUT                                                                 */
+/*                                                                        */
+/*    decrypted_packet                      Decrypted record (possibly    */
+/*                                            spanning chained fragments) */
+/*    message_type_ptr                      Set to the inner content type */
+/*    message_length_ptr                    Set to the length excluding   */
+/*                                            the type byte and padding   */
+/*                                                                        */
+/*  OUTPUT                                                                */
+/*                                                                        */
+/*    NX_SECURE_TLS_SUCCESS                 Inner type recovered          */
+/*    NX_SECURE_TLS_UNEXPECTED_MESSAGE      Plaintext had no non-zero     */
+/*                                            byte (§5.4 violation)       */
+/*                                                                        */
+/**************************************************************************/
+UINT _nx_secure_tls_1_3_strip_padding(NX_PACKET *decrypted_packet,
+                                      USHORT *message_type_ptr,
+                                      UINT *message_length_ptr)
+{
+NX_PACKET *scan_fragment;
+UCHAR     *scan_ptr;
+ULONG      running_offset      = 0;
+ULONG      last_nonzero_offset = 0;
+UCHAR      last_nonzero_byte   = 0;
+
+    for (scan_fragment = decrypted_packet; scan_fragment != NX_NULL; scan_fragment = scan_fragment -> nx_packet_next)
+    {
+        for (scan_ptr = scan_fragment -> nx_packet_prepend_ptr;
+             scan_ptr < scan_fragment -> nx_packet_append_ptr;
+             scan_ptr++)
+        {
+            if (*scan_ptr != 0)
+            {
+                last_nonzero_byte   = *scan_ptr;
+                last_nonzero_offset = running_offset;
+            }
+            running_offset++;
+        }
+    }
+
+    if (last_nonzero_byte == 0)
+    {
+        *message_type_ptr   = 0;
+        *message_length_ptr = 0;
+        decrypted_packet -> nx_packet_length = 0;
+        return(NX_SECURE_TLS_UNEXPECTED_MESSAGE);
+    }
+
+    *message_type_ptr   = (USHORT)last_nonzero_byte;
+    *message_length_ptr = last_nonzero_offset;
+    decrypted_packet -> nx_packet_length = last_nonzero_offset;
+    return(NX_SECURE_TLS_SUCCESS);
+}
+#endif /* NX_SECURE_TLS_TLS_1_3_ENABLED */

--- a/nx_secure/src/nx_secure_tls_process_record.c
+++ b/nx_secure/src/nx_secure_tls_process_record.c
@@ -26,12 +26,6 @@
 
 static VOID _nx_secure_tls_packet_trim(NX_PACKET *packet_ptr);
 
-#if (NX_SECURE_TLS_TLS_1_3_ENABLED)
-UINT _nx_secure_tls_1_3_strip_padding(NX_PACKET *decrypted_packet,
-                                      USHORT *message_type_ptr,
-                                      UINT *message_length_ptr);
-#endif
-
 /**************************************************************************/
 /*                                                                        */
 /*  FUNCTION                                               RELEASE        */

--- a/nx_secure/src/nx_secure_tls_process_record.c
+++ b/nx_secure/src/nx_secure_tls_process_record.c
@@ -276,22 +276,43 @@ NX_PACKET *decrypted_packet;
                 if (status == NX_SECURE_TLS_SUCCESS)
                 {
 
-                    /* In TLS 1.3, encrypted records have a single byte at the
-                    record that contains the message type (e.g. application data,
-                    ect.), which is now the ACTUAL message type. */
-                    status = nx_packet_data_extract_offset(decrypted_packet,
-                                                           decrypted_packet -> nx_packet_length - 1,
-                                                           &message_type, 1, &bytes_copied);
-                    if (status || (bytes_copied != 1))
+                    /* RFC 8446 §5.4: the inner content type is the last
+                     * NON-ZERO byte of the plaintext; everything after it is
+                     * record padding. Reading the literal last byte broke any
+                     * padded record (Java JDK HttpClient pads by default) —
+                     * scan back, skip the zeros.
+                     */
                     {
-                        error_status = NX_SECURE_TLS_INVALID_PACKET;
+                        ULONG scan_offset = decrypted_packet -> nx_packet_length;
+                        message_type = 0;
+                        while (scan_offset > 0)
+                        {
+                            scan_offset--;
+                            status = nx_packet_data_extract_offset(decrypted_packet,
+                                                                   scan_offset,
+                                                                   &message_type, 1, &bytes_copied);
+                            if (status || (bytes_copied != 1))
+                            {
+                                error_status = NX_SECURE_TLS_INVALID_PACKET;
+                                message_type = 0;
+                                break;
+                            }
+                            if (message_type != 0)
+                            {
+                                break;
+                            }
+                        }
+                        if (message_type == 0)
+                        {
+                            error_status = NX_SECURE_TLS_INVALID_PACKET;
+                            message_length = 0;
+                        }
+                        else
+                        {
+                            message_length = scan_offset;
+                        }
+                        decrypted_packet -> nx_packet_length = message_length;
                     }
-
-                    /* Remove the content type byte from the data length to process. */
-                    message_length = message_length - 1;
-
-                    /* Adjust packet length. */
-                    decrypted_packet -> nx_packet_length = message_length;
 
                     /* Increment the sequence number. This is done in the MAC verify
                     step for 1.2 and earlier, but AEAD includes the MAC so we don't

--- a/test/regression/nx_secure_test/nx_secure_tls_process_record_test.c
+++ b/test/regression/nx_secure_test/nx_secure_tls_process_record_test.c
@@ -20,12 +20,6 @@
 #if !defined(NX_SECURE_TLS_CLIENT_DISABLED) && !defined(NX_SECURE_TLS_SERVER_DISABLED)
 extern VOID    test_control_return(UINT status);
 
-#if (NX_SECURE_TLS_TLS_1_3_ENABLED)
-extern UINT _nx_secure_tls_1_3_strip_padding(NX_PACKET *decrypted_packet,
-                                             USHORT *message_type_ptr,
-                                             UINT *message_length_ptr);
-#endif
-
 #define METADATA_SIZE               16000
 #define NUM_PACKETS                 24
 #define PACKET_SIZE                 1536

--- a/test/regression/nx_secure_test/nx_secure_tls_process_record_test.c
+++ b/test/regression/nx_secure_test/nx_secure_tls_process_record_test.c
@@ -20,6 +20,12 @@
 #if !defined(NX_SECURE_TLS_CLIENT_DISABLED) && !defined(NX_SECURE_TLS_SERVER_DISABLED)
 extern VOID    test_control_return(UINT status);
 
+#if (NX_SECURE_TLS_TLS_1_3_ENABLED)
+extern UINT _nx_secure_tls_1_3_strip_padding(NX_PACKET *decrypted_packet,
+                                             USHORT *message_type_ptr,
+                                             UINT *message_length_ptr);
+#endif
+
 #define METADATA_SIZE               16000
 #define NUM_PACKETS                 24
 #define PACKET_SIZE                 1536
@@ -228,6 +234,107 @@ UCHAR packet_buffer[100];
 
     status = _nx_secure_tls_process_record(&tls_session, packet, &bytes_processed, 0);
     EXPECT_EQ(NX_SECURE_TLS_INVALID_PACKET, status);
+
+#if (NX_SECURE_TLS_TLS_1_3_ENABLED)
+    /* Regression tests for the TLS 1.3 record de-padding (RFC 8446 §5.4).
+       Before the fix, the code read the literal last byte of the plaintext
+       as the inner content type; any padded record from a compliant peer
+       (JDK 11+, OpenSSL with padding on) was mishandled. */
+    {
+        NX_PACKET *decrypted;
+        USHORT     out_type;
+        UINT       out_length;
+        UCHAR      inner_plaintext[16];
+
+        /* Case 1: padded record. Plaintext = "hello" + type byte + 5 zeros.
+           The inner type must come back and the length must exclude both
+           the type byte and the padding. */
+        tls_session.nx_secure_record_queue_header = NX_NULL;
+        status = nx_packet_allocate(&pool_0, &decrypted, NX_IPv4_TCP_PACKET, NX_WAIT_FOREVER);
+        EXPECT_EQ(NX_SUCCESS, status);
+
+        memset(inner_plaintext, 0, sizeof(inner_plaintext));
+        memcpy(inner_plaintext, "hello", 5);
+        inner_plaintext[5] = NX_SECURE_TLS_APPLICATION_DATA;
+        status = nx_packet_data_append(decrypted, inner_plaintext, 11, &pool_0, NX_WAIT_FOREVER);
+        EXPECT_EQ(NX_SUCCESS, status);
+
+        out_type   = 0;
+        out_length = 0;
+        status = _nx_secure_tls_1_3_strip_padding(decrypted, &out_type, &out_length);
+        EXPECT_EQ(NX_SECURE_TLS_SUCCESS, status);
+        EXPECT_EQ((USHORT)NX_SECURE_TLS_APPLICATION_DATA, out_type);
+        EXPECT_EQ((UINT)5, out_length);
+        EXPECT_EQ((ULONG)5, decrypted -> nx_packet_length);
+
+        status = nx_packet_release(decrypted);
+        EXPECT_EQ(NX_SUCCESS, status);
+
+        /* Case 2: all-zero plaintext. §5.4 says this is a peer protocol
+           violation and must yield unexpected_message. */
+        status = nx_packet_allocate(&pool_0, &decrypted, NX_IPv4_TCP_PACKET, NX_WAIT_FOREVER);
+        EXPECT_EQ(NX_SUCCESS, status);
+
+        memset(inner_plaintext, 0, sizeof(inner_plaintext));
+        status = nx_packet_data_append(decrypted, inner_plaintext, 10, &pool_0, NX_WAIT_FOREVER);
+        EXPECT_EQ(NX_SUCCESS, status);
+
+        out_type   = 0xff;
+        out_length = 42;
+        status = _nx_secure_tls_1_3_strip_padding(decrypted, &out_type, &out_length);
+        EXPECT_EQ(NX_SECURE_TLS_UNEXPECTED_MESSAGE, status);
+        EXPECT_EQ((USHORT)0, out_type);
+        EXPECT_EQ((UINT)0, out_length);
+
+        status = nx_packet_release(decrypted);
+        EXPECT_EQ(NX_SUCCESS, status);
+
+        /* Case 3: unpadded record. Pre-fix arithmetic gave length - 1; the
+           new scan must return the exact same values so existing traffic is
+           unaffected. This is the regression-risk assertion. */
+        status = nx_packet_allocate(&pool_0, &decrypted, NX_IPv4_TCP_PACKET, NX_WAIT_FOREVER);
+        EXPECT_EQ(NX_SUCCESS, status);
+
+        memcpy(inner_plaintext, "hello", 5);
+        inner_plaintext[5] = NX_SECURE_TLS_APPLICATION_DATA;
+        status = nx_packet_data_append(decrypted, inner_plaintext, 6, &pool_0, NX_WAIT_FOREVER);
+        EXPECT_EQ(NX_SUCCESS, status);
+
+        out_type   = 0;
+        out_length = 0;
+        status = _nx_secure_tls_1_3_strip_padding(decrypted, &out_type, &out_length);
+        EXPECT_EQ(NX_SECURE_TLS_SUCCESS, status);
+        EXPECT_EQ((USHORT)NX_SECURE_TLS_APPLICATION_DATA, out_type);
+        EXPECT_EQ((UINT)5, out_length);
+
+        status = nx_packet_release(decrypted);
+        EXPECT_EQ(NX_SUCCESS, status);
+
+        /* Case 4: padded record that straddles a fragment boundary. The scan
+           must walk through the chained NX_PACKETs, not just the head. */
+        status = nx_packet_allocate(&pool_0, &decrypted, NX_IPv4_TCP_PACKET, NX_WAIT_FOREVER);
+        EXPECT_EQ(NX_SUCCESS, status);
+
+        /* Payload > single-packet capacity (1536) forces chaining. Fill with
+           a non-zero content byte, then the type, then trailing zeros — the
+           trailing zeros will land in a later fragment. */
+        memset(data_buffer, 0xAB, 2000);
+        data_buffer[1999] = NX_SECURE_TLS_APPLICATION_DATA;
+        memset(&data_buffer[2000], 0, 500);
+        status = nx_packet_data_append(decrypted, data_buffer, 2500, &pool_0, NX_WAIT_FOREVER);
+        EXPECT_EQ(NX_SUCCESS, status);
+
+        out_type   = 0;
+        out_length = 0;
+        status = _nx_secure_tls_1_3_strip_padding(decrypted, &out_type, &out_length);
+        EXPECT_EQ(NX_SECURE_TLS_SUCCESS, status);
+        EXPECT_EQ((USHORT)NX_SECURE_TLS_APPLICATION_DATA, out_type);
+        EXPECT_EQ((UINT)1999, out_length);
+
+        status = nx_packet_release(decrypted);
+        EXPECT_EQ(NX_SUCCESS, status);
+    }
+#endif /* NX_SECURE_TLS_TLS_1_3_ENABLED */
 
     printf("SUCCESS!\n");
     test_control_return(0);


### PR DESCRIPTION
## Summary

A TLS 1.3 peer that pads its records cannot talk to NetX Duo: the very first padded record is rejected and the connection is torn down with a fatal alert.

Per [RFC 8446 §5.4](https://www.rfc-editor.org/rfc/rfc8446#section-5.4), the decrypted TLS 1.3 record is:

```
struct {
    opaque content[TLSPlaintext.length];
    ContentType type;
    uint8 zeros[length_of_padding];
} TLSInnerPlaintext;
```

The receiver must scan from the end of the plaintext, skipping zero bytes, to find the inner content type. `_nx_secure_tls_process_record()` instead reads the literal last byte as the content type and strips exactly one byte. For any padded record the extracted type is `0x00` (invalid, later rejected as an unrecognized message type), and the padding bytes would remain inside the message content.

Record padding is not exotic: the Java JDK (11+) TLS 1.3 implementation sends padded records (encountered in the field with a Java client), and OpenSSL produces them with `-record_padding N`.

## Changes

- **`nx_secure/src/nx_secure_tls_process_record.c`** — after decryption of a TLS 1.3 record, scan backward from the end of the plaintext skipping zero bytes; the first non-zero byte is the inner content type, and the message length is set to exclude the type byte and the padding. A plaintext consisting only of zeros is rejected (`NX_SECURE_TLS_INVALID_PACKET`), as required by §5.4 ("If a receiving implementation does not find a non-zero octet in the cleartext, it MUST terminate the connection").

Unpadded records take the same path as before: the first byte inspected (the last plaintext byte) is non-zero and the resulting length is unchanged.

Note: for the all-zeros case, RFC 8446 prescribes an `unexpected_message` alert; `NX_SECURE_TLS_INVALID_PACKET` currently maps to the internal-error alert group in `_nx_secure_tls_map_error_to_alert()`. The connection is still terminated with a fatal alert; happy to adjust the mapping if a stricter alert code is preferred.

## Test plan

- [x] TLS 1.3 session against a peer sending padded records (Java 11+ HTTPS client): previously failed on the first encrypted record, now completes
- [x] OpenSSL with `-record_padding N`: handshake and application data exchange succeed
- [x] Unpadded TLS 1.3 traffic (OpenSSL/Mosquitto defaults): unchanged
- [x] TLS 1.2 record processing: not affected (code path is TLS 1.3-only)
