### PR TITLE
Fix MQTT client: clear credentials and will on connection teardown

### DIFF
--- a/addons/mqtt/nxd_mqtt_client.c
+++ b/addons/mqtt/nxd_mqtt_client.c
@@ -1950,13 +1950,6 @@ UCHAR       fixed_header;
         client_ptr -> nxd_mqtt_ping_sent_time = 0;
     }
 
-    /* Clean up the information when disconnecting. */
-    client_ptr -> nxd_mqtt_client_username = NX_NULL;
-    client_ptr -> nxd_mqtt_client_password = NX_NULL;
-    client_ptr -> nxd_mqtt_client_will_topic = NX_NULL;
-    client_ptr -> nxd_mqtt_client_will_message = NX_NULL;
-    client_ptr -> nxd_mqtt_client_will_qos_retain = 0;
-
     /* Release current processing packet. */
     if (client_ptr -> nxd_mqtt_client_processing_packet)
     {
@@ -2570,6 +2563,14 @@ VOID _nxd_mqtt_client_connection_end(NXD_MQTT_CLIENT *client_ptr, ULONG wait_opt
 #endif
     nx_tcp_socket_disconnect(&(client_ptr -> nxd_mqtt_client_socket), wait_option);
     nx_tcp_client_socket_unbind(&(client_ptr -> nxd_mqtt_client_socket));
+
+    /* Clean up per-connection information so a failed or ended connection
+       never leaks credentials or will settings into the next CONNECT. */
+    client_ptr -> nxd_mqtt_client_username = NX_NULL;
+    client_ptr -> nxd_mqtt_client_password = NX_NULL;
+    client_ptr -> nxd_mqtt_client_will_topic = NX_NULL;
+    client_ptr -> nxd_mqtt_client_will_message = NX_NULL;
+    client_ptr -> nxd_mqtt_client_will_qos_retain = 0;
 
     /* Disable timer if timer has been started. */
     if (client_ptr -> nxd_mqtt_keepalive)
@@ -3750,9 +3751,19 @@ UINT                 old_priority;
         {
             nx_secure_tls_session_delete(&(client_ptr -> nxd_mqtt_tls_session));
         }
+        client_ptr -> nxd_mqtt_client_use_tls = 0;
 #endif /* NX_SECURE_ENABLE */
         nx_tcp_client_socket_unbind(&(client_ptr -> nxd_mqtt_client_socket));
         tx_timer_delete(&(client_ptr -> nxd_mqtt_timer));
+
+        /* Same per-connection cleanup as _nxd_mqtt_client_connection_end —
+           this early-failure path is the only teardown that does not go
+           through it. */
+        client_ptr -> nxd_mqtt_client_username = NX_NULL;
+        client_ptr -> nxd_mqtt_client_password = NX_NULL;
+        client_ptr -> nxd_mqtt_client_will_topic = NX_NULL;
+        client_ptr -> nxd_mqtt_client_will_message = NX_NULL;
+        client_ptr -> nxd_mqtt_client_will_qos_retain = 0;
         return(NXD_MQTT_CONNECT_FAILURE);
     }
 


### PR DESCRIPTION
## Summary

The credentials and will pointers stored in the client (`nxd_mqtt_client_username` / `password` / `will_topic` / `will_message`, set by `nxd_mqtt_client_login_set()` and `nxd_mqtt_client_will_message_set()`) must be cleared on every connection teardown, error paths included. Today only the clean-disconnect path clears them, in `_nxd_mqtt_process_disconnect()`; the failed-connect teardowns (CONNACK refused, TCP or TLS establish failure) go through `_nxd_mqtt_client_connection_end()` and keep the stale pointers. If the application then reconfigures the same client for an anonymous connection (no new `login_set()` call) and its old buffers have been zeroed or reused, the next CONNECT goes out with the username flag set but no valid username. Mosquitto drops it as a protocol error (`CONNECT with username flag but no username`) and `nxd_mqtt_client_secure_connect()` fails with `NXD_MQTT_COMMUNICATION_FAILURE` (0x10007), on every retry, until the device reboots.

Observed during TLS/MQTT test-bench runs: connect attempts with credentials failed while the server certificate was temporarily invalid, the configuration was then switched back to an anonymous account, and the live client could never reconnect.

## Changes

- **`addons/mqtt/nxd_mqtt_client.c`**
  - Move the username/password/will cleanup from `_nxd_mqtt_process_disconnect()` into `_nxd_mqtt_client_connection_end()`, so every teardown path resets it. `_nxd_mqtt_process_disconnect()` calls `_nxd_mqtt_client_connection_end()`, so the clean-disconnect behavior is unchanged.
  - Apply the same cleanup in the early TCP-connect-failure branch of `_nxd_mqtt_client_connect()`, the only teardown that does not go through `_nxd_mqtt_client_connection_end()`. Also clear `nxd_mqtt_client_use_tls` there: that branch has the same stale-flag problem that #400 fixes in `_nxd_mqtt_client_connection_end()`, on a path #400 does not cover. (The two PRs touch different hunks and merge independently.)

Behavioral note: credentials were already cleared on every clean disconnect by `_nxd_mqtt_process_disconnect()`, so the effective contract is already "call `login_set()` before each connect that needs credentials". This change only extends the existing cleanup to the failure paths.

## Test plan

- [x] Reproduced on mosquitto: after a failed connect with credentials, an anonymous reconnect on the same client sends `CONNECT` with the username flag and no username, and is dropped by the broker as a protocol error
- [x] Audit of all teardown call sites: `_nxd_mqtt_process_disconnect`, `_nxd_mqtt_process_connack` error path, TCP/TLS establish-process failures, and the early TCP-failure branch of `_nxd_mqtt_client_connect` all reset the credentials with this change
- [ ] Full device-level regression on our gateway test bench with the patched library, including secure and plain connect/disconnect/reconnect cycles with credentials re-set before each connect (in progress)
