### PR TITLE
Changed the FTP server to send 226 after closing the data connection

### DIFF
--- a/addons/ftp/nxd_ftp_server.c
+++ b/addons/ftp/nxd_ftp_server.c
@@ -64,7 +64,7 @@ NX_CALLER_CHECKING_EXTERNS
 #define NX_FTP_CODE_CMD_OK           "200"  /* Command okay.  */
 #define NX_FTP_CODE_CONNECTION_OK    "220"  /* Connection okay.  */
 #define NX_FTP_CODE_CLOSE            "221"  /* Service closing control connection.  */
-#define NX_FTP_CODE_LOGOFF           "226"  /* Closing data connection.  */
+#define NX_FTP_CODE_CLOSING_DATA     "226"  /* Closing data connection.  */
 #define NX_FTP_CODE_LOGIN            "230"  /* User logged in, proceed.  */
 #define NX_FTP_CODE_COMPLETED        "250"  /* Requested file action okay, completed.  */
 #define NX_FTP_CODE_MADE_DIR         "257"  /* PATHNAME created.  */
@@ -2012,7 +2012,7 @@ ULONG                   block_size;
                             /* The read command was successful!  */
                             /* Now send a successful response to the client.  */
                             _nx_ftp_server_response(&(client_req_ptr -> nx_ftp_client_request_control_socket), packet_ptr,
-                                        NX_FTP_CODE_LOGOFF, "File Sent");
+                                        NX_FTP_CODE_CLOSING_DATA, "File Sent");
                         }
                         else
                         {
@@ -2965,7 +2965,7 @@ ULONG                   block_size;
 
                             /* Now send a successful response to the client.  */
                             _nx_ftp_server_response(&(client_req_ptr -> nx_ftp_client_request_control_socket), packet_ptr,
-                                        NX_FTP_CODE_LOGOFF, "List End");
+                                        NX_FTP_CODE_CLOSING_DATA, "List End");
                         }
                         else
                         {
@@ -3436,7 +3436,7 @@ ULONG                   block_size;
 
                             /* Now send a successful response to the client.  */
                             _nx_ftp_server_response(&(client_req_ptr -> nx_ftp_client_request_control_socket), packet_ptr,
-                                        NX_FTP_CODE_LOGOFF, "List End");
+                                        NX_FTP_CODE_CLOSING_DATA, "List End");
                         }
                         else
                         {
@@ -4596,7 +4596,7 @@ NX_FTP_CLIENT_REQUEST   *client_req_ptr;
 
                     /* Now send "250" message to indicate successful file write.  */
                     _nx_ftp_server_response(&(client_req_ptr -> nx_ftp_client_request_control_socket), packet_ptr,
-                                NX_FTP_CODE_LOGOFF, "File Written");
+                                NX_FTP_CODE_CLOSING_DATA, "File Written");
                 }
                 else
                 {

--- a/addons/ftp/nxd_ftp_server.c
+++ b/addons/ftp/nxd_ftp_server.c
@@ -2012,7 +2012,7 @@ ULONG                   block_size;
                             /* The read command was successful!  */
                             /* Now send a successful response to the client.  */
                             _nx_ftp_server_response(&(client_req_ptr -> nx_ftp_client_request_control_socket), packet_ptr,
-                                        NX_FTP_CODE_COMPLETED, "File Sent");
+                                        NX_FTP_CODE_LOGOFF, "File Sent");
                         }
                         else
                         {
@@ -2965,7 +2965,7 @@ ULONG                   block_size;
 
                             /* Now send a successful response to the client.  */
                             _nx_ftp_server_response(&(client_req_ptr -> nx_ftp_client_request_control_socket), packet_ptr,
-                                        NX_FTP_CODE_COMPLETED, "List End");
+                                        NX_FTP_CODE_LOGOFF, "List End");
                         }
                         else
                         {
@@ -3436,7 +3436,7 @@ ULONG                   block_size;
 
                             /* Now send a successful response to the client.  */
                             _nx_ftp_server_response(&(client_req_ptr -> nx_ftp_client_request_control_socket), packet_ptr,
-                                        NX_FTP_CODE_COMPLETED, "List End");
+                                        NX_FTP_CODE_LOGOFF, "List End");
                         }
                         else
                         {
@@ -4596,7 +4596,7 @@ NX_FTP_CLIENT_REQUEST   *client_req_ptr;
 
                     /* Now send "250" message to indicate successful file write.  */
                     _nx_ftp_server_response(&(client_req_ptr -> nx_ftp_client_request_control_socket), packet_ptr,
-                                NX_FTP_CODE_COMPLETED, "File Written");
+                                NX_FTP_CODE_LOGOFF, "File Written");
                 }
                 else
                 {

--- a/addons/ftp/nxd_ftp_server.c
+++ b/addons/ftp/nxd_ftp_server.c
@@ -4594,7 +4594,7 @@ NX_FTP_CLIENT_REQUEST   *client_req_ptr;
 
                     /* Successful client file write.  */
 
-                    /* Now send "250" message to indicate successful file write.  */
+                    /* Send 226 (Closing data connection) response code. */
                     _nx_ftp_server_response(&(client_req_ptr -> nx_ftp_client_request_control_socket), packet_ptr,
                                 NX_FTP_CODE_CLOSING_DATA, "File Written");
                 }

--- a/test/regression/ftp_test/netx_ftp_commands_replys_test.c
+++ b/test/regression/ftp_test/netx_ftp_commands_replys_test.c
@@ -404,9 +404,9 @@ UCHAR            *message;
         reply_counter[1] = NX_TRUE;
     else if(!memcmp(message,"200 Type Binary",15))
         reply_counter[2] = NX_TRUE;
-    else if(!memcmp(message,"250 File Sent",13))
+    else if(!memcmp(message,"226 File Sent",13))
         reply_counter[3] = NX_TRUE;
-    else if(!memcmp(message,"250 File Written ",16))
+    else if(!memcmp(message,"226 File Written",16))
         reply_counter[4] = NX_TRUE;
     else if(!memcmp( message,"200 NOOP Success",16))
         reply_counter[5] = NX_TRUE;


### PR DESCRIPTION
## Description
This PR fixes a critical state-machine issue where the NetX Duo FTP server sends the unconventional FTP reply code (250) after closing a data connection, instead of the RFC 959 compliant code (226).

## Impact
Standard-compliant FTP clients (e.g., standard Yocto FTP clients, Rust FTP clients) hang indefinitely after downloading a file, uploading a file, or requesting a directory listing. The clients detect that the data connection was closed but wait endlessly for the 226 Transfer complete code on the control channel to properly finalize the transaction.  

## Root Cause
According to RFC 959:

- 250 Requested file action okay, completed should only be used when the command does not involve closing a data connection (e.g., RNTO, DELE).

- 226 Closing data connection must be sent to indicate that a data transfer (like RETR, STOR, LIST, NLST) has concluded successfully and the data port was closed.

In nxd_ftp_server.c, the macro NX_FTP_CODE_COMPLETED ("250") is currently hardcoded for all successful operations, including those that close the data socket (lines processing RETR, STOR, LIST, and NLST).  


Wireshark traces clearly show the following sequence:

1. Data transferred via the data channel.
2. Server sends TCP [FIN, ACK] on the data channel (closing it correctly).
3. Server sends 250 File Sent / 250 List End on the control channel instead of 226. 

## Evidence of Protocol Violation

**1. Application Layer (Control Channel)**
The server incorrectly replies with `250` instead of `226` after the transfer is done:
```text
227 Entering Passive Mode (10,0,0,27,192,5).
---> LIST
125 Sending List 
drw-rw-rw-  1 owner group          0 JAN 01 00:00 testfolder
-rw-rw-rw-  1 owner group         12 JAN 01 00:00 testdata.txt
250 List End
``` 

The Wireshark capture of the corresponding data port shows that the server (10.0.0.27) explicitly closes the socket by sending a [FIN, ACK] (Packet 201), proving that a 226 response was required:

<img width="2336" height="267" alt="Screenshot from 2026-07-14 09-15-12" src="https://github.com/user-attachments/assets/bcab0117-0069-4be2-adf7-6153f438d901" />


## Solution implemented
link macro `NX_FTP_CODE_CLOSING_DATA` correcly if a connection cleanup occurs previously 

Replaced the incorrect NX_FTP_CODE_COMPLETED macro in nxd_ftp_server.c for the RETR, STOR, LIST, and NLST command processing blocks.  

Operations without data channels (like DELE, RNTO, CWD) correctly retain the 250 response code.  

This fully restores interoperability with strict FTP clients.
Greetings David