### PR TITLE
Fixed the mDNS build on big-endian ports

### DIFF
--- a/addons/mdns/nxd_mdns.c
+++ b/addons/mdns/nxd_mdns.c
@@ -8486,7 +8486,8 @@ UINT                i;
     if (more_known_answer)
     {                  
         tc_bit = NX_MDNS_TC_FLAG;
-         *(USHORT *)(packet_ptr -> nx_packet_prepend_ptr + NX_MDNS_FLAGS_OFFSET) |= NX_CHANGE_USHORT_ENDIAN(tc_bit);
+        NX_CHANGE_USHORT_ENDIAN(tc_bit);
+        *(USHORT *)(packet_ptr -> nx_packet_prepend_ptr + NX_MDNS_FLAGS_OFFSET) |= tc_bit;
     }
 
     /* Update the question count in header.  */


### PR DESCRIPTION
nxd_mdns.c uses NX_CHANGE_USHORT_ENDIAN() as an expression:

    *(USHORT *)(packet_ptr -> nx_packet_prepend_ptr + NX_MDNS_FLAGS_OFFSET)
        |= NX_CHANGE_USHORT_ENDIAN(tc_bit);

Big-endian ports define that macro as empty, so it expands to "*(USHORT *)(...) |= ;" and addons/mdns fails to compile on every big-endian target.

It goes unnoticed on little-endian because those ports define the macro as an assignment -- a = (((a >> 8) | (a << 8)) & 0xFFFF) -- which has a value and so parses in expression position. Every other call site in the repository uses the macro as a statement, which is what an unconditionally-empty definition requires; see for example test/regression/ptp_test/netx_ptp_utility.c. This is the only expression use.

Swap in place, then OR, which keeps the macro used as a statement.

Verified against both upstream definitions: with the big-endian (empty) definition the original fails to compile and this compiles; with the little-endian definition both produce the same flags word, 0x0002.

Found while building addons/mdns for m68k AmigaOS.