### PR TITLE
Released the DRBG mutex when generation fails

### DIFF
--- a/crypto_libraries/src/nx_crypto_drbg.c
+++ b/crypto_libraries/src/nx_crypto_drbg.c
@@ -1174,12 +1174,13 @@ UINT status;
     }
 
     status = _nx_crypto_drbg_generate(&_nx_crypto_drbg_ctx, result, bytes, NX_CRYPTO_NULL, 0);
+
+    NX_CRYPTO_DRBG_MUTEX_PUT;
+
     if (status)
     {
         return(status);
     }
-
-    NX_CRYPTO_DRBG_MUTEX_PUT;
 
     /* Zero out extra bits generated. */
     bits = bits & 7;


### PR DESCRIPTION
## Summary

`_nx_crypto_drbg()` takes `NX_CRYPTO_DRBG_MUTEX_GET` at the top, but returns early when `_nx_crypto_drbg_generate()` fails, so the mutex is never released.

Both macros are empty by default and nothing in the repository defines them, so a default build is unaffected. Ports that do define them get a permanent deadlock instead of a returned error.

The failure path is not obscure. `_nx_crypto_drbg_generate()` has three failure returns, but two are `NX_CRYPTO_SIZE_ERROR` on `additional_input_len`, which `_nx_crypto_drbg()` always passes as 0 — unreachable from this caller. The third, `NX_CRYPTO_NO_INSTANCE` (`nx_crypto_drbg.c:509-512`), fires exactly when `_nx_crypto_drbg_initialize()` on the line above failed. So the leak is on the one error this caller can actually produce, driven by the ignored return value right above it.

It also matters where this sits: in `NX_CRYPTO_SELF_TEST` builds `_nx_crypto_drbg()` *is* `NX_CRYPTO_RBG` (`nx_crypto.h:92`), so on a port that defines the mutex macros, this deadlocks the generator behind EC key generation and ECDSA signing (`nx_crypto_ec.c:2945` and `:4671`) — the RNG for the whole FIPS configuration, not a peripheral path.

Found while working on #399.

## Changes

- **`crypto_libraries/src/nx_crypto_drbg.c`** — move `NX_CRYPTO_DRBG_MUTEX_PUT` to just after `_nx_crypto_drbg_generate()`, before the status check. This also leaves the masking of the extra bits outside the critical section, which is fine since it only touches the caller's buffer.

The ignored `_nx_crypto_drbg_initialize()` return value on the line above is a separate question: after this fix, an initialisation failure already propagates correctly (`NX_CRYPTO_NO_INSTANCE`, mutex released) via `_nx_crypto_drbg_generate()`'s check, so there's no defect left there — only a readability improvement to surface the real error code sooner. Leaving it for a follow-up.

## Test plan

- [x] No behaviour change in a default build, where both macros expand to nothing
- [x] Compiles clean under `-Wall -Wextra -Wconversion`
- [x] Expanded both macros to function calls and checked there is exactly one get and one put, with the put now unconditional
- [ ] Not exercised at runtime: I have no port here that defines the mutex macros, so the deadlock itself is reasoned from the code rather than reproduced