### PR TITLE
Fixed an ASN.1 over-read by reading the tag after the length check

### DIFF
--- a/nx_secure/src/nx_secure_x509_asn1_tlv_block_parse.c
+++ b/nx_secure/src/nx_secure_x509_asn1_tlv_block_parse.c
@@ -125,12 +125,13 @@ ULONG  length;
 ULONG  length_bytes;
 
     current_index = 0;
-    current_tag = buffer[current_index];
 
     if (*buffer_length < 1)
     {
         return(NX_SECURE_X509_ASN1_LENGTH_TOO_LONG);
     }
+
+    current_tag = buffer[current_index];
 
     /*  Handle multi-byte encoded tags. */
     if ((current_tag & NX_SECURE_ASN_TAG_MULTIBYTE_MASK) == NX_SECURE_ASN_TAG_MULTIBYTE_MASK)


### PR DESCRIPTION
_nx_secure_x509_asn1_tlv_block_parse() loaded buffer[0] into current_tag one statement before testing *buffer_length < 1, so every caller that runs out of data read one byte past the end of the buffer it was given.

It is reachable from the wire. A certificate two bytes long reaches it through _nx_secure_x509_certificate_parse(), and so does the issuer walk in the certificate store, which calls the parser repeatedly as it consumes a chain and hands it whatever remains.

Found by a fuzz driver over _nx_secure_tls_process_remote_certificate() with a real DER corpus, and confirmed under AddressSanitizer.

The read is moved below the guard. The guard already returned the right status; only the load was in the wrong place.