### PR TITLE
tls: bound the ServerHello ciphersuite and compression method

### DIFF
--- a/nx_secure/src/nx_secure_tls_process_serverhello.c
+++ b/nx_secure/src/nx_secure_tls_process_serverhello.c
@@ -170,6 +170,13 @@ NX_SECURE_TLS_SERVER_STATE            old_client_state = tls_session -> nx_secur
         length += tls_session -> nx_secure_tls_session_id_length;
     }
 
+    /* The ciphersuite is two bytes and the compression method one more. The
+       check above bounded the session ID, not what follows it. */
+    if ((length + 3) > message_length)
+    {
+        return(NX_SECURE_TLS_INCORRECT_MESSAGE_LENGTH);
+    }
+
     /* Finally, the chosen ciphersuite - this is selected by the server from the list we provided in the ClientHello. */
     ciphersuite = (USHORT)((packet_buffer[length] << 8) + packet_buffer[length + 1]);
     length += 2;


### PR DESCRIPTION
_nx_secure_tls_process_serverhello() checked that the session ID fitted and then read three more bytes without checking anything.

The floor is message_length < 38. After the protocol version and the 32-byte random, length is 35, and the session ID check is

    if ((length + session_id_length) > message_length)

so a 38-byte ServerHello may carry a session_id_length of 3 and leave length at exactly 38. The two ciphersuite bytes are then read at [38] and [39], and the compression method at [40] -- three bytes past the message.

A server chooses both fields, so this is reachable by any peer a client connects to.

The session ID check bounds the session ID. This adds the one the fields after it need.

Found by a fuzz driver over the client handshake path and confirmed under AddressSanitizer.