### PR TITLE
tls: bound the CertificateRequest certificate-type count

### DIFF
--- a/nx_secure/src/nx_secure_tls_process_certificate_request.c
+++ b/nx_secure/src/nx_secure_tls_process_certificate_request.c
@@ -218,6 +218,13 @@ UINT extension_type;
 #endif
     {
 
+        /* The count is one byte, and nothing above guarantees there is one:
+           the length test in the TLS 1.3 arm does not run for TLS 1.2. */
+        if (message_length < 1)
+        {
+            return(NX_SECURE_TLS_INCORRECT_MESSAGE_LENGTH);
+        }
+
         /* Extract the count of certificate types from the incoming data. */
         cert_types_length = packet_buffer[length];
         length += 1;


### PR DESCRIPTION
_nx_secure_tls_process_certificate_request() read the certificate-type count out of the message before establishing that the message had a byte in it.

The only guard is

    if (length >= message_length)

which sits inside the NX_SECURE_TLS_TLS_1_3_ENABLED arm, above the else. For TLS 1.2 nothing runs before

    cert_types_length = packet_buffer[length];

with length still 0, so a zero-length CertificateRequest reads one byte past the record buffer. The sanity test that follows compares cert_types_length against message_length, which is after the read.

A server sends CertificateRequest and chooses its length, so this is reachable by any peer a client connects to.

Found by a fuzz driver over the client handshake path and confirmed under AddressSanitizer.