### PR TITLE
Remove obsolete Azure IoT CI jobs

### DIFF
--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -104,45 +104,6 @@ jobs:
       result_affix: NetXDuo_Fast
       skip_deploy: true
       skip_coverage: true
-  Azure_IoT:
-    permissions:
-      contents: read
-      issues: read
-      checks: write
-      pull-requests: write
-      pages: write
-      id-token: write
-    uses: eclipse-threadx/threadx/.github/workflows/regression_template.yml@master
-    with:
-      build_script: ./scripts/build_azure_iot.sh
-      test_script: ./scripts/test_azure_iot.sh
-      cmake_path: ./test/cmake/azure_iot
-      result_affix: Azure_IoT
-      skip_deploy: true
-  Azure_IoT_Windows:
-    permissions:
-      contents: read
-      issues: read
-      checks: write
-      pull-requests: write
-    runs-on: windows-2019
-    steps:
-    - name: Check out the repository
-      uses: actions/checkout@v4
-      with:
-        submodules: true
-    - name: Checkout submodules
-      run: |
-        if (!(Test-Path ./test/cmake/threadx)) {git clone https://github.com/eclipse-threadx/threadx.git ./test/cmake/threadx --depth 1}
-    - name: CMake
-      run: |
-        mkdir build
-        cd build
-        cmake ../test/cmake/azure_iot -A Win32
-    - name: Build
-      run: |
-        cd build
-        cmake --build .
   Secure:
     permissions:
       contents: read
@@ -213,8 +174,8 @@ jobs:
       pull-requests: write
       pages: write
       id-token: write
-    needs: [NetXDuo, Web, MQTT, NetXDuo64, NetXDuo_Fast, Azure_IoT, Secure, Crypto, Secure_Interoperability, MQTT_Interoperability]
+    needs: [NetXDuo, Web, MQTT, NetXDuo64, NetXDuo_Fast, Secure, Crypto, Secure_Interoperability, MQTT_Interoperability]
     uses: eclipse-threadx/threadx/.github/workflows/regression_template.yml@master
     with:
       skip_test: true
-      deploy_list: "NetXDuo Web MQTT NetXDuo64 NetXDuo_Fast Azure_IoT Secure Crypto Secure_Interoperability MQTT_Interoperability"
+      deploy_list: "NetXDuo Web MQTT NetXDuo64 NetXDuo_Fast Secure Crypto Secure_Interoperability MQTT_Interoperability"


### PR DESCRIPTION
## Summary

- remove the Linux Azure IoT regression job
- remove the Windows Azure IoT build job
- remove Azure IoT from the deploy job's dependencies and result list

## Rationale

The Azure IoT client is scheduled for removal from this repository, so maintaining dedicated Linux and Windows CI jobs for it is no longer useful. The Windows job also targets the retired `windows-2019` GitHub-hosted runner.

## Impact

Azure IoT will no longer be built or tested by this workflow. All remaining NetX Duo, Secure, Crypto, MQTT, Web, PTP, and interoperability jobs are unchanged.

## Validation

- parsed `.github/workflows/regression_test.yml` successfully as YAML
- confirmed the workflow contains no `Azure_IoT`, `azure_iot`, or `windows-2019` references
- `git diff --check`: passed

This infrastructure change is intentionally separate from #423.
